### PR TITLE
Add an unadvertised --no-cache-lookup option...

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,6 +3,7 @@ env:
   amd: true
   es6: true
 extends: 'eslint:recommended'
+parser: 'babel-eslint'
 parserOptions:
   ecmaVersion: 8
 rules:

--- a/helpers.js
+++ b/helpers.js
@@ -183,6 +183,7 @@ const doAnalysis = async (client, config, jsonFiles, contractNames = null, limit
    * Prepare for progress bar
    */
     const progress = ('progress' in config) ? config.progress : true;
+    const cacheLookup = ('cache-lookup' in config) ? config['cache-lookup'] : true;
     let multi;
     let indent;
     if (progress) {
@@ -219,8 +220,9 @@ const doAnalysis = async (client, config, jsonFiles, contractNames = null, limit
         const timeout = (config.timeout || 300) * 1000;
 
         let analyzeOpts = {
-            timeout,
             clientToolName: 'truffle',
+            noCacheLookup: !cacheLookup,
+            timeout,
         };
 
         analyzeOpts.data = cleanAnalyDataEmptyProps(obj.buildObj, config.debug,
@@ -252,7 +254,6 @@ const doAnalysis = async (client, config, jsonFiles, contractNames = null, limit
 
         // request analysis to armlet.
         try {
-	    debugger
             const {issues, status} = await client.analyzeWithStatus(analyzeOpts);
             if (config.debug) {
                 config.logger.debug(`UUID for this job is ${status.uuid}`);

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -1,40 +1,40 @@
 const isFatal = (fatal, severity) => fatal || severity === 2;
 
 const getUniqueMessages = messages => {
-  const jsonValues = messages.map(m => JSON.stringify(m));
-  const uniuqeValues = jsonValues.reduce((accum, curr) => {
-      if (accum.indexOf(curr) === -1) {
-          accum.push(curr);
-      }
-      return accum;
-  }, []);
+    const jsonValues = messages.map(m => JSON.stringify(m));
+    const uniuqeValues = jsonValues.reduce((accum, curr) => {
+        if (accum.indexOf(curr) === -1) {
+            accum.push(curr);
+        }
+        return accum;
+    }, []);
 
-  return uniuqeValues.map(v => JSON.parse(v));
-}
+    return uniuqeValues.map(v => JSON.parse(v));
+};
 
 const calculateErrors = messages =>
-  messages.reduce((acc,  { fatal, severity }) => isFatal(fatal , severity) ? acc + 1: acc, 0);
+    messages.reduce((acc,  { fatal, severity }) => isFatal(fatal , severity) ? acc + 1: acc, 0);
 
 const calculateWarnings = messages =>
-  messages.reduce((acc,  { fatal, severity }) => !isFatal(fatal , severity) ? acc + 1: acc, 0);
+    messages.reduce((acc,  { fatal, severity }) => !isFatal(fatal , severity) ? acc + 1: acc, 0);
 
 
 const getUniqueIssues = issues => 
-  issues.map(({ messages, ...restProps }) => {
-    const uniqueMessages = getUniqueMessages(messages);
-    const warningCount = calculateWarnings(uniqueMessages);
-    const errorCount = calculateErrors(uniqueMessages);
+    issues.map(({ messages, ...restProps }) => {
+        const uniqueMessages = getUniqueMessages(messages);
+        const warningCount = calculateWarnings(uniqueMessages);
+        const errorCount = calculateErrors(uniqueMessages);
 
-    return {
-        ...restProps,
-        messages: uniqueMessages,
-        errorCount,
-        warningCount,
-    };
-  });
+        return {
+            ...restProps,
+            messages: uniqueMessages,
+            errorCount,
+            warningCount,
+        };
+    });
 
 module.exports = {
-  getUniqueIssues,
-  getUniqueMessages,
-  isFatal,
-}
+    getUniqueIssues,
+    getUniqueMessages,
+    isFatal,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-security",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -252,17 +252,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "armlet": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/armlet/-/armlet-1.2.1.tgz",
-      "integrity": "sha512-Oz+eLInnC6GCOP212U13Ja1uClz3TVDYiTolX0YfqQgxpL3SRUWVBT/FPrCPMxBhDWVZCa3jlevsvlReRm7eFw==",
-      "requires": {
-        "http-errors": "^1.7.1",
-        "humanize-duration": "^3.17.0",
-        "moment": "^2.24.0",
-        "request": "^2.88.0"
-      }
-    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -394,6 +383,32 @@
           "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
+        }
+      }
+    },
+    "babel-eslint": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
+      "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+          "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
         }
       }
     },
@@ -2249,18 +2264,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "http-errors": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.1.tgz",
-      "integrity": "sha512-jWEUgtZWGSMba9I1N3gc1HmvpBUaNC9vDdA46yScAdp+C5rdEuKWUBLWTQpW9FwSWSbYYs++b6SDCxf9UEJzfw==",
-      "requires": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      }
-    },
     "http-https": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
@@ -2275,11 +2278,6 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
-    },
-    "humanize-duration": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.17.0.tgz",
-      "integrity": "sha512-9em7CXFa0my1DF3aIQg0sTRyAX2znEOMHolUvu9nSTUjS+bRD32y0MH+Hnm3Xu0cSWrxpYb2isXSfH9pF2LP8g=="
     },
     "iconv-lite": {
       "version": "0.4.23",
@@ -3267,11 +3265,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
       "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA="
-    },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "mout": {
       "version": "0.11.1",
@@ -6418,11 +6411,6 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
-    },
-    "toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "tough-cookie": {
       "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "license": "MIT",
   "main": "index.js",
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "coveralls": "^3.0.2",
     "eslint": ">=5.9.0",
     "ipfsd-ctl": "^0.21.0",

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -291,9 +291,9 @@ describe('helpers.js', function() {
 
         beforeEach(() => {
             armletClient = new armlet.Client({
-		ethAddress: rewiredHelpers.trialEthAddress,
-		password: rewiredHelpers.trialPassword
-	    });
+                ethAddress: rewiredHelpers.trialEthAddress,
+                password: rewiredHelpers.trialPassword
+            });
             stubAnalyze = sinon.stub(armletClient, 'analyzeWithStatus');
             debuggerStub = sinon.stub();
         });
@@ -348,9 +348,10 @@ describe('helpers.js', function() {
             const results = await doAnalysis(armletClient, config, jsonFiles);
             mythXInput.analysisMode = 'quick';
             assert.ok(stubAnalyze.calledWith({
-                data: mythXInput,
-                timeout: 300000,
                 clientToolName: 'truffle',
+                data: mythXInput,
+                noCacheLookup: false,
+                timeout: 300000,
             }));
             assert.equal(results.errors.length, 0);
             assert.equal(results.objects.length, 1);
@@ -377,9 +378,10 @@ describe('helpers.js', function() {
             const results = await doAnalysis(armletClient, config, jsonFiles);
             mythXInput.analysisMode = 'quick';
             assert.ok(stubAnalyze.calledWith({
-                data: mythXInput,
-                timeout: 300000,
                 clientToolName: 'truffle',
+                data: mythXInput,
+                noCacheLookup: false,
+                timeout: 300000,
             }));
             assert.equal(results.errors.length, 1);
             assert.equal(results.objects.length, 0);
@@ -435,9 +437,10 @@ describe('helpers.js', function() {
             const results = await doAnalysis(armletClient, config, jsonFiles);
             mythXInput.analysisMode = 'quick';
             assert.ok(stubAnalyze.calledWith({
-                data: mythXInput,
-                timeout: 300000,
                 clientToolName: 'truffle',
+                data: mythXInput,
+                noCacheLookup: false,
+                timeout: 300000,
             }));
             assert.equal(results.errors.length, 1);
             assert.equal(results.objects.length, 1);


### PR DESCRIPTION
Fix the eslint problem caused by introducing `...`

@daniyarchambylov I would appreciate it if you would change the tests so that the are not so fragile when adding a parameter like noCacheLookup.  Two problems

1) adding a field breaks tests. (Fields are always going to be added and I don't want to keep updating tests when they do)
2) You have to change something like 4 places because the same code appears. Please DRY (Do not repeat yourself)