### PR TITLE
Document the previously secret --no-color option

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -98,6 +98,8 @@ Options:
   --version  Show package and MythX version information.
   --no-progress
              Do not display progress bars during analysis.
+  --no-color
+             Do not display colors.
 `;
         // FIXME: decide if this is okay or whether we need
         // to pass in `config` and use `config.logger.log`.


### PR DESCRIPTION
The [colors package](https://www.npmjs.com/package/colors) we use implements a `--no-color` option. We'll claim it for ourselves and put it in our help message.

closes #86 