### PR TITLE
"err" sometimes is not a string - coerce it before relying on string-…

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -286,9 +286,11 @@ const doAnalysis = async (client, config, jsonFiles, contractNames = null, limit
             if (progress) {
                 clearInterval(timer);
                 sleep.msleep(1000); // wait for last setInterval finising
-                // Check error message from armlet to determine if a timeout occured.
-                if(err.includes('User or default timeout reached after')
-                   || err.includes('Timeout reached after')) {
+                // Check error message from armlet to determine if a timeout occurred.
+                // Coerce err to string just in case it is not one.
+                const errStr =`${err}`;
+                if (errStr.includes('User or default timeout reached after')
+                   || errStr.includes('Timeout reached after')) {
                   bar.tick({
                       'status': `✗ timeout`.yellow
                   });


### PR DESCRIPTION
…ness

I ran across this in running truffle-security over aragonOS. 

```
Internal MythX errors encountered:
...
TimeHelpersMock: [object Object]
TokenMock: [object Object]
Uint256Mock: [object Object]
...
```

I will be tacking what's going on here. But for robustness, this patch forces stringness before it is relied on. 

@tagomaru please also review. 