### PR TITLE
Change err to string with JSON.stringify if it is just a object except Error.

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -79,11 +79,8 @@ Runs MythX analyses on given Solidity contracts. If no contracts are
 given, all are analyzed.
 
 Options:
-  --debug    Provide additional debug output. Use --debug=2 for more
-             verbose output
-  --uuid *UUID*
-             Print in YAML results from a prior run having *UUID*
-             Note: this is still a bit raw and will be improved.
+  --all
+             Compile all contracts instead of only the contracts changed since last compile.
   --mode { quick | full }
              Perform quick or in-depth (full) analysis.
   --style { stylish | json | table | tap | unix | ... },
@@ -105,11 +102,16 @@ Options:
              As results come back, remaining contracts are submitted.
              The default is ${defaultAnalyzeRateLimit} contracts, the maximum value, but you can
              set this lower.
+  --debug    Provide additional debug output. Use --debug=2 for more
+             verbose output
+  --uuid *UUID*
+             Print in YAML results from a prior run having *UUID*
+             Note: this is still a bit raw and will be improved.
   --version  Show package and MythX version information.
   --progress, --no-progress
-             enable/disable progress bars during analysis. The default is enabled.
+             Enable/disable progress bars during analysis. The default is enabled.
   --color, --no-color
-             enabling/disabling output coloring. The default is enabled.
+             Enable/disable output coloring. The default is enabled.
 `;
         // FIXME: decide if this is okay or whether we need
         // to pass in `config` and use `config.logger.log`.
@@ -309,7 +311,7 @@ const doAnalysis = async (client, config, contracts, contractNames = null, limit
 
             // Get message property of err.
             // If err is not Error object, coerce err to string to avoid possible problem in subsequent processing.
-            const errStr = (typeof err.message) === 'string' ? err.message : `${err}`;
+            const errStr = (typeof err.message) === 'string' ? err.message : `${util.inspect(err)}`;
 
             // Check error message from armlet to determine if a timeout occurred.
             if (errStr.includes('User or default timeout reached after')

--- a/helpers.js
+++ b/helpers.js
@@ -311,7 +311,11 @@ const doAnalysis = async (client, config, contracts, contractNames = null, limit
 
             // Get message property of err.
             // If err is not Error object, coerce err to string to avoid possible problem in subsequent processing.
-            const errStr = (typeof err.message) === 'string' ? err.message : `${util.inspect(err)}`;
+            const errStr = (
+		(typeof err.message) === 'string'
+		    ? err.message
+		    : (conf.debug ? `${util.inspect(err)}`: `${err}`)
+	    );
 
             // Check error message from armlet to determine if a timeout occurred.
             if (errStr.includes('User or default timeout reached after')

--- a/helpers.js
+++ b/helpers.js
@@ -314,7 +314,7 @@ const doAnalysis = async (client, config, contracts, contractNames = null, limit
             const errStr = (
 		(typeof err.message) === 'string'
 		    ? err.message
-		    : (conf.debug ? `${util.inspect(err)}`: `${err}`)
+		    : (config.debug ? `${util.inspect(err)}`: `${err}`)
 	    );
 
             // Check error message from armlet to determine if a timeout occurred.

--- a/helpers.js
+++ b/helpers.js
@@ -309,13 +309,19 @@ const doAnalysis = async (client, config, contracts, contractNames = null, limit
                 sleep.msleep(1000); // wait for last setInterval finising
             }
 
-            // Get message property of err.
-            // If err is not Error object, coerce err to string to avoid possible problem in subsequent processing.
-            const errStr = (
-		(typeof err.message) === 'string'
-		    ? err.message
-		    : (config.debug ? `${util.inspect(err)}`: `${err}`)
-	    );
+            // Get string type error massage from err.
+            let errStr;
+            if (typeof err.message === 'string') {
+                // If err is Error, get message property.
+                errStr = err.message;
+            } else if (typeof err === 'object') {
+                // If err is object, coerce err to string to avoid possible problem in subsequent processing.
+                errStr = JSON.stringify(err);
+            } else {
+                // If err is not either Error or object, coerce it to string to avoid possible problem in subsequent processing.
+                // However this might worth nothing.
+                errStr = `${err}`;
+            }
 
             // Check error message from armlet to determine if a timeout occurred.
             if (errStr.includes('User or default timeout reached after')


### PR DESCRIPTION
@rocky 
I believe [object Object] problem does not happen now thanks to your below effort.

https://github.com/ConsenSys/armlet/commit/552cde28b61d8b7932969baff1a95713d6abc605

According to my test, the problem occurs if errStr of `(buildObj.contractName + ": ").red + errStr` is not Error but object.
And ${err} does not work, it means if it is object, it will be object as well.

I believe this problem does not happen now, but I add the logic to change err to string with JSON.strigify for the future just in case.

Thx!

