### PR TITLE
support project config file for advanced options & extend options for filtering SWCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ Options:
              set this lower.
   --debug    Provide additional debug output. Use --debug=2 for more
              verbose output
-  --minSeverity { warning | error }
+  --min-severity { warning | error }
              Ignore SWCs below the designated level
-  --swcBlacklist { ["SWC-103"] | ["SWC-101", "SWC-111"] | ...}
+  --swc-blacklist { ["SWC-103"] | ["SWC-101", "SWC-111"] | ...}
              Ignore a specific SWC or list of SWCs.
   --uuid *UUID*
              Print in YAML results from a prior run having *UUID*
@@ -136,7 +136,7 @@ Configuration options can also be stored as json in `truffle-security.json` at t
 {
     "style": "table",
     "mode": "quick",
-    "minSeverity": "warning",
-    "swcBlacklist": ["SWC-103"]
+    "min-severity": "warning",
+    "swc-blacklist": ["SWC-103"]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Options:
              verbose output
   --min-severity { warning | error }
              Ignore SWCs below the designated level
-  --swc-blacklist { 101 | 103,111,115 | ... }
+  --swc-blacklist { 101 | [103,111,115] | ... }
              Ignore a specific SWC or list of SWCs.
   --uuid *UUID*
              Print in YAML results from a prior run having *UUID*
@@ -137,6 +137,6 @@ Configuration options can also be stored as json in `truffle-security.json` at t
     "style": "table",
     "mode": "quick",
     "min-severity": "warning",
-    "swc-blacklist": "103,111"
+    "swc-blacklist": [103,111]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -137,6 +137,6 @@ Configuration options can also be stored as json in `truffle-security.json` at t
     "style": "table",
     "mode": "quick",
     "min-severity": "warning",
-    "swc-blacklist": ["SWC-103"]
+    "swc-blacklist": "103,111"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Options:
              verbose output
   --min-severity { warning | error }
              Ignore SWCs below the designated level
-  --swc-blacklist { 101 | [103,111,115] | ... }
+  --swc-blacklist { 101 | 103,111,115 | ... }
              Ignore a specific SWC or list of SWCs.
   --uuid *UUID*
              Print in YAML results from a prior run having *UUID*

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Configuration options can also be stored as json in `truffle-security.json` at t
 ```
 {
     "style": "table",
-    "mode": "quick ",
+    "mode": "quick",
     "minSeverity": "warning",
     "swcBlacklist": ["SWC-103"]
 }

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Options:
              set this lower.
   --debug    Provide additional debug output. Use --debug=2 for more
              verbose output
+  --minSeverity { warning | error }
+             Ignore SWCs below the designated level
+  --swcBlacklist { ["SWC-103"] | ["SWC-101", "SWC-111"] | ...}
+             Ignore a specific SWC or list of SWCs.
   --uuid *UUID*
              Print in YAML results from a prior run having *UUID*
              Note: this is still a bit raw and will be improved.
@@ -126,4 +130,13 @@ Options:
              Enable/disable output coloring. The default is enabled.
 
 
+```
+Configuration options can also be stored as json in `truffle-security.json` at the truffle project root. i.e. : 
+```
+{
+    "style": "table",
+    "mode": "quick ",
+    "minSeverity": "warning",
+    "swcBlacklist": ["SWC-103"]
+}
 ```

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Options:
              verbose output
   --min-severity { warning | error }
              Ignore SWCs below the designated level
-  --swc-blacklist { ["SWC-103"] | ["SWC-101", "SWC-111"] | ...}
+  --swc-blacklist { 101 | 103,111,115 | ... }
              Ignore a specific SWC or list of SWCs.
   --uuid *UUID*
              Print in YAML results from a prior run having *UUID*

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+    "style": "stylish"
+}

--- a/config.json
+++ b/config.json
@@ -1,3 +1,5 @@
 {
-    "style": "stylish"
+    "style": "stylish",
+    "minSeverity": "warning",
+    "swcBlacklist": ["SWC-101"]
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,0 @@
-{
-    "style": "stylish",
-    "minSeverity": "warning",
-    "swcBlacklist": ["SWC-101"]
-}

--- a/helpers.js
+++ b/helpers.js
@@ -3,9 +3,6 @@
 
 const armlet = require('armlet');
 const path = require('path');
-// TODO really this is about the location
-// in the consumer of this plugin, not the plugin itself
-const projectConfig = require('./config.json');
 const trufstuf = require('./lib/trufstuf');
 const { MythXIssues } = require('./lib/issues2eslint');
 const eslintHelpers = require('./lib/eslint');
@@ -496,8 +493,13 @@ const getArmletClient = (ethAddress, password, clientToolName = 'truffle') => {
  */
 async function analyze(config) {
 
-    // include options from project configuration file
-    config = Object.assign(config, projectConfig);
+    try {
+	const projectConfig = require([config.working_directory,
+				       'truffle-security-config.json'].join ('/'));
+	config = Object.assign(config, projectConfig);
+    } catch (ex) {
+	console.log("No truffle security configuration file found");
+    }
 
     const limit = config.limit || defaultAnalyzeRateLimit;
     const log = config.logger.log;

--- a/helpers.js
+++ b/helpers.js
@@ -380,8 +380,8 @@ function doReport(config, objects, errors, notAnalyzedContracts) {
     } else {
         const spaceLimited = ['tap', 'markdown', 'json'].indexOf(config.style) === -1;
         const eslintIssues = objects
-              .map(obj => obj.getEslintIssues(config, spaceLimited))
-              .reduce((acc, curr) => acc.concat(curr), []);
+            .map(obj => obj.getEslintIssues(config, spaceLimited))
+            .reduce((acc, curr) => acc.concat(curr), []);
 
         // FIXME: temporary solution until backend will return correct filepath and output.
         const eslintIssuesByBaseName = groupEslintIssuesByBasename(eslintIssues);

--- a/helpers.js
+++ b/helpers.js
@@ -452,6 +452,29 @@ function ghettoReport(logger, results) {
     return 1;
 }
 
+function setConfigSeverityLevel (inputSeverity) {
+
+    // converting severity to a number makes it easier to deal with in `issues2eslint.js`
+    const severity2Number = {
+        'error': 2,
+        'warning': 1
+    };
+
+    // default to `warning`
+    return severity2Number[inputSeverity] || 1;
+}
+
+function setConfigSWCBlacklist (inputBlacklist) {
+    if (!inputBlacklist) {
+        return false;
+    }
+
+    return inputBlacklist
+        .toString()
+        .split(",")
+        .map(swc => "SWC-" + swc.trim());
+}
+
 /**
  * Modifies attributes of the Truffle configuration object
  * in order to use project-defined options
@@ -482,23 +505,8 @@ function prepareConfig (config) {
     }
 
     // modify and extend initial config params
-    const severity2Number = {
-        'error': 2,
-        'warning': 1
-    };
-
-    // converting to severity to a number makes it easier to deal with in `issues2eslint.js`
-    // default to `warning`
-    if ([config['min-severity']]) {
-        config.severityThreshold = severity2Number[config['min-severity']] || 1;
-    }
-
-    if (config['swc-blacklist']) {
-        config.swcBlacklist = config['swc-blacklist']
-            .toString()
-            .split(",")
-            .map(swc => "SWC-" + swc.trim());
-    }
+    config.severityThreshold = setConfigSeverityLevel(config['min-severity']);
+    config.swcBlacklist = setConfigSWCBlacklist(config['swc-blacklist']);
 
     return config;
 }

--- a/helpers.js
+++ b/helpers.js
@@ -495,11 +495,13 @@ async function analyze(config) {
 
     try {
       const projectConfig = require([config.working_directory,
-				       'truffle-security.json'].join ('/'));
-      config = Object.assign(config, projectConfig);
+				     'truffle-security.json'].join ('/'));
+	// command line options should overwrite project-level config
+	config = Object.assign(projectConfig, config);
     } catch (ex) {
-      // TODO how chatty should this logging be?
-      // console.log("No truffle security configuration file found");
+	if (config.debug >1) {
+	    console.log("No truffle security configuration file found");
+	}
     }
 
     const limit = config.limit || defaultAnalyzeRateLimit;

--- a/helpers.js
+++ b/helpers.js
@@ -494,13 +494,12 @@ const getArmletClient = (ethAddress, password, clientToolName = 'truffle') => {
 async function analyze(config) {
 
     try {
-        const projectConfig = require([config.working_directory,
-				     'truffle-security.json'].join ('/'));
+        const projectConfig = require([config.working_directory, 'truffle-security.json'].join ('/'));
         // command line options should overwrite project-level config
         config = Object.assign(projectConfig, config);
     } catch (ex) {
         if (config.debug >1) {
-           console.log("No truffle security configuration file found");
+            console.log("No truffle security configuration file found");
         }
     }
 

--- a/helpers.js
+++ b/helpers.js
@@ -540,6 +540,10 @@ async function analyze(config) {
     // Get list of smart contract build json files from truffle build folder
     const jsonFiles = await trufstuf.getTruffleBuildJsonFiles(config.build_mythx_contracts);
 
+    if (!config.style) {
+        config.style = 'stylish';
+    }
+
     const buildObjs = await Promise.all(jsonFiles.map(async file => await trufstuf.parseBuildJson(file)));
     const objContracts = buildObjs.reduce((resultContracts, obj) => {
         const contracts = mythx.newTruffleObjToOldTruffleByContracts(obj);

--- a/helpers.js
+++ b/helpers.js
@@ -715,6 +715,8 @@ module.exports = {
     printHelpMessage,
     contractsCompile,
     doAnalysis,
+    setConfigSeverityLevel,
+    setConfigSWCBlacklist,
     cleanAnalyzeDataEmptyProps,
     getArmletClient,
     trialEthAddress,

--- a/helpers.js
+++ b/helpers.js
@@ -500,7 +500,7 @@ async function analyze(config) {
         config = Object.assign(projectConfig, config);
     } catch (ex) {
         if (config.debug >1) {
-	    console.log("No truffle security configuration file found");
+           console.log("No truffle security configuration file found");
         }
     }
 

--- a/helpers.js
+++ b/helpers.js
@@ -3,6 +3,8 @@
 
 const armlet = require('armlet');
 const path = require('path');
+// TODO really this is about the location
+// in the consumer of this plugin, not the plugin itself
 const projectConfig = require('./config.json');
 const trufstuf = require('./lib/trufstuf');
 const { MythXIssues } = require('./lib/issues2eslint');
@@ -381,7 +383,7 @@ function doReport(config, objects, errors, notAnalyzedContracts) {
     } else {
         const spaceLimited = ['tap', 'markdown', 'json'].indexOf(config.style) === -1;
         const eslintIssues = objects
-              .map(obj => obj.getEslintIssues(spaceLimited))
+              .map(obj => obj.getEslintIssues(config, spaceLimited))
               .reduce((acc, curr) => acc.concat(curr), []);
 
         // FIXME: temporary solution until backend will return correct filepath and output.

--- a/helpers.js
+++ b/helpers.js
@@ -3,6 +3,7 @@
 
 const armlet = require('armlet');
 const path = require('path');
+const projectConfig = require('./config.json');
 const trufstuf = require('./lib/trufstuf');
 const { MythXIssues } = require('./lib/issues2eslint');
 const eslintHelpers = require('./lib/eslint');
@@ -492,6 +493,10 @@ const getArmletClient = (ethAddress, password, clientToolName = 'truffle') => {
  * @param {Object} config - truffle configuration object.
  */
 async function analyze(config) {
+
+    // include options from project configuration file
+    config = Object.assign(config, projectConfig);
+
     const limit = config.limit || defaultAnalyzeRateLimit;
     const log = config.logger.log;
 
@@ -529,10 +534,6 @@ async function analyze(config) {
 
     // Get list of smart contract build json files from truffle build folder
     const jsonFiles = await trufstuf.getTruffleBuildJsonFiles(config.build_mythx_contracts);
-
-    if (!config.style) {
-        config.style = 'stylish';
-    }
 
     const buildObjs = await Promise.all(jsonFiles.map(async file => await trufstuf.parseBuildJson(file)));
     const objContracts = buildObjs.reduce((resultContracts, obj) => {

--- a/helpers.js
+++ b/helpers.js
@@ -106,7 +106,7 @@ Options:
              Note: progress is disabled if this is set.
   --min-severity { warning | error }
              Ignore SWCs below the designated level
-  --swc-blacklist { ["SWC-103"] | ["SWC-101", "SWC-111"] | ...}
+  --swc-blacklist { 101 | 103,111,115 | ... }
              Ignore a specific SWC or list of SWCs.
   --uuid *UUID*
              Print in YAML results from a prior run having *UUID*
@@ -462,7 +462,7 @@ function ghettoReport(logger, results) {
 
 function prepareConfig (config) {
 
-    // merge project level configuration if present
+    // merge project level configuration
     try {
         let projectConfig = require([config.working_directory, 'truffle-security'].join ('/'));
 
@@ -481,10 +481,7 @@ function prepareConfig (config) {
         }
     }
 
-    // convert kebab-case to camelCase
-    config.swcBlacklist = config['swc-blacklist'];
-    config.minSeverity = config['min-severity'];
-
+    // modify and extend initial config params
     const severity2Number = {
         'error': 2,
         'warning': 1
@@ -492,7 +489,16 @@ function prepareConfig (config) {
 
     // converting to severity to a number makes it easier to deal with in `issues2eslint.js`
     // default to `warning`
-    config.severityThreshold = severity2Number[config.minSeverity] || 1;
+    if ([config['min-severity']]) {
+        config.severityThreshold = severity2Number[config['min-severity']] || 1;
+    }
+
+    if (config['swc-blacklist']) {
+        config.swcBlacklist = config['swc-blacklist']
+            .toString()
+            .split(",")
+            .map(swc => "SWC-" + swc.trim());
+    }
 
     return config;
 }

--- a/helpers.js
+++ b/helpers.js
@@ -494,14 +494,14 @@ const getArmletClient = (ethAddress, password, clientToolName = 'truffle') => {
 async function analyze(config) {
 
     try {
-      const projectConfig = require([config.working_directory,
+        const projectConfig = require([config.working_directory,
 				     'truffle-security.json'].join ('/'));
-	// command line options should overwrite project-level config
-	config = Object.assign(projectConfig, config);
+        // command line options should overwrite project-level config
+        config = Object.assign(projectConfig, config);
     } catch (ex) {
-	if (config.debug >1) {
+        if (config.debug >1) {
 	    console.log("No truffle security configuration file found");
-	}
+        }
     }
 
     const limit = config.limit || defaultAnalyzeRateLimit;

--- a/helpers.js
+++ b/helpers.js
@@ -498,7 +498,7 @@ async function analyze(config) {
         // command line options should overwrite project-level config
         config = Object.assign(projectConfig, config);
     } catch (ex) {
-        if (config.debug >1) {
+        if (config.debug > 1) {
             console.log("No truffle security configuration file found");
         }
     }

--- a/helpers.js
+++ b/helpers.js
@@ -495,7 +495,7 @@ async function analyze(config) {
 
     try {
       const projectConfig = require([config.working_directory,
-				       'truffle-security-config.json'].join ('/'));
+				       'truffle-security.json'].join ('/'));
       config = Object.assign(config, projectConfig);
     } catch (ex) {
       // TODO how chatty should this logging be?

--- a/helpers.js
+++ b/helpers.js
@@ -104,6 +104,10 @@ Options:
   --debug    Provide additional debug output. Use --debug=2 for more
              verbose output
              Note: progress is disabled if this is set.
+  --min-severity { warning | error }
+             Ignore SWCs below the designated level
+  --swc-blacklist { ["SWC-103"] | ["SWC-101", "SWC-111"] | ...}
+             Ignore a specific SWC or list of SWCs.
   --uuid *UUID*
              Print in YAML results from a prior run having *UUID*
              Note: this is still a bit raw and will be improved.

--- a/helpers.js
+++ b/helpers.js
@@ -494,12 +494,12 @@ const getArmletClient = (ethAddress, password, clientToolName = 'truffle') => {
 async function analyze(config) {
 
     try {
-	const projectConfig = require([config.working_directory,
+      const projectConfig = require([config.working_directory,
 				       'truffle-security-config.json'].join ('/'));
-	config = Object.assign(config, projectConfig);
+      config = Object.assign(config, projectConfig);
     } catch (ex) {
-	// TODO how chatty should this logging be?
-	// console.log("No truffle security configuration file found");
+      // TODO how chatty should this logging be?
+      // console.log("No truffle security configuration file found");
     }
 
     const limit = config.limit || defaultAnalyzeRateLimit;

--- a/helpers.js
+++ b/helpers.js
@@ -474,7 +474,6 @@ function prepareConfig (config) {
             }
         });
 
-
     } catch (ex) {
         if (config.debug > 1) {
             config.logger.error("truffle-security.json either not found or improperly formatted.");
@@ -494,7 +493,7 @@ function prepareConfig (config) {
     // converting to severity to a number makes it easier to deal with in `issues2eslint.js`
     // default to `warning`
     config.severityThreshold = severity2Number[config.minSeverity] || 1;
-    console.log(config.minSeverity);
+
     return config;
 }
 

--- a/helpers.js
+++ b/helpers.js
@@ -498,7 +498,8 @@ async function analyze(config) {
 				       'truffle-security-config.json'].join ('/'));
 	config = Object.assign(config, projectConfig);
     } catch (ex) {
-	console.log("No truffle security configuration file found");
+	// TODO how chatty should this logging be?
+	// console.log("No truffle security configuration file found");
     }
 
     const limit = config.limit || defaultAnalyzeRateLimit;

--- a/lib/issues2eslint.js
+++ b/lib/issues2eslint.js
@@ -19,21 +19,19 @@ const mythx2Severity = {
 
 const isFatal = (fatal, severity) => fatal || severity === 2;
 
-const severeEnough = (severity, threshold) => severity >= threshold;
-
 const keepIssueInResults = function (issue, config) {
 
-    if (config.minSeverity) {
-        // we will only keep the issue if its severity is at or above the config threshold
-        return severeEnough(issue.severity, severityThreshold);
+    // omit this issue if its severity is below the config threshold
+    if (config.severityThreshold  && issue.severity < config.severityThreshold) {
+        return false;
     }
 
-    if (config.swcBlacklist) {
-        // we will only keep the issue if it is NOT included in the blacklist
-        return !config.swcBlacklist.includes(issue.ruleId)
+    // omit this if its swc code is included in the blacklist
+    if (config.swcBlacklist && config.swcBlacklist.includes(issue.ruleId)) {
+        return false;
     }
 
-    // if an issue hasn't been filtered out by severity or blacklist, than keep it
+    // if an issue hasn't been filtered out by severity or blacklist, then keep it
     return true;
 
 };
@@ -286,7 +284,6 @@ class MythXIssues {
             filePath: source,
         };
         const sourceName = path.basename(source);
-
         result.messages = issues
             .map(issue => this.issue2EsLint(issue, spaceLimited, sourceFormat, sourceName))
             .filter(issue => keepIssueInResults(issue, config));
@@ -312,5 +309,5 @@ class MythXIssues {
 
 module.exports = {
     MythXIssues,
-    displayCriteria
+    keepIssueInResults
 };

--- a/lib/issues2eslint.js
+++ b/lib/issues2eslint.js
@@ -17,27 +17,23 @@ const mythx2Severity = {
     Medium: 1,
 };
 
-const severity2Number = {
-    'error': 2,
-    'warning': 1
-};
-
 const isFatal = (fatal, severity) => fatal || severity === 2;
 
-const displayCriteria = function (issue, config) {
+const severeEnough = (severity, threshold) => severity >= threshold;
 
-    // convert the config log level to a number, default to "warning"
-    let severityThreshold = severity2Number[config.minSeverity] || 1;
+const keepIssueInResults = function (issue, config) {
 
-    if (issue.severity < severityThreshold) {
-        return false;
+    if (config.minSeverity) {
+        // we will only keep the issue if its severity is at or above the config threshold
+        return severeEnough(issue.severity, severityThreshold);
     }
 
-    // filter out SWC codes included in the config blacklist
-    if (config.swcBlacklist && config.swcBlacklist.includes(issue.ruleId)) {
-        return false;
+    if (config.swcBlacklist) {
+        // we will only keep the issue if it is NOT included in the blacklist
+        return !config.swcBlacklist.includes(issue.ruleId)
     }
 
+    // if an issue hasn't been filtered out by severity or blacklist, than keep it
     return true;
 
 };
@@ -293,7 +289,7 @@ class MythXIssues {
 
         result.messages = issues
             .map(issue => this.issue2EsLint(issue, spaceLimited, sourceFormat, sourceName))
-            .filter(issue => displayCriteria(issue, config));
+            .filter(issue => keepIssueInResults(issue, config));
 
         result.warningCount = result.messages.reduce((acc,  { fatal, severity }) =>
             !isFatal(fatal , severity) ? acc + 1: acc, 0);

--- a/lib/issues2eslint.js
+++ b/lib/issues2eslint.js
@@ -17,7 +17,30 @@ const mythx2Severity = {
     Medium: 1,
 };
 
+const logLevel2Severity = {
+    "error": 2,
+    "warning": 1
+};
+
 const isFatal = (fatal, severity) => fatal || severity === 2;
+
+const displayCriteria = function (issue, config) {
+
+    // convert the config log level to a number, default to "warning"
+    let severityThreshold = logLevel2Severity[config.minSeverity] || 1;
+
+    if (issue.severity < severityThreshold) {
+	return false;
+    }
+
+    // filter out SWC codes included in the config blacklist
+    if (config.swcBlacklist.includes(issue.ruleId)) {
+	return false;
+    }
+
+    return true;
+
+};
 
 
 class MythXIssues {
@@ -257,7 +280,7 @@ class MythXIssues {
      * @param {boolean} spaceLimited
      * @returns {object}
      */
-    convertMythXReport2EsIssue(report, spaceLimited) {
+    convertMythXReport2EsIssue(report, config, spaceLimited) {
         const { issues, sourceFormat, source } = report;
         const result = {
             errorCount: 0,
@@ -268,7 +291,9 @@ class MythXIssues {
         };
         const sourceName = path.basename(source);
 
-        result.messages = issues.map(issue => this.issue2EsLint(issue, spaceLimited, sourceFormat, sourceName));
+        result.messages = issues
+	    .map(issue => this.issue2EsLint(issue, spaceLimited, sourceFormat, sourceName))
+	    .filter(issue => displayCriteria(issue, config));
 
         result.warningCount = result.messages.reduce((acc,  { fatal, severity }) =>
             !isFatal(fatal , severity) ? acc + 1: acc, 0);
@@ -284,8 +309,8 @@ class MythXIssues {
      * @param {boolean} spaceLimited
      * @returns {object[]}
      */
-    getEslintIssues(spaceLimited = false) {
-        return this.issues.map(report => this.convertMythXReport2EsIssue(report, spaceLimited));
+    getEslintIssues(config, spaceLimited = false) {
+        return this.issues.map(report => this.convertMythXReport2EsIssue(report, config, spaceLimited));
     }
 }
 

--- a/lib/issues2eslint.js
+++ b/lib/issues2eslint.js
@@ -316,4 +316,5 @@ class MythXIssues {
 
 module.exports = {
     MythXIssues,
+    displayCriteria
 };

--- a/lib/issues2eslint.js
+++ b/lib/issues2eslint.js
@@ -17,7 +17,7 @@ const mythx2Severity = {
     Medium: 1,
 };
 
-const logLevel2Severity = {
+const severity2Number = {
     'error': 2,
     'warning': 1
 };
@@ -27,7 +27,7 @@ const isFatal = (fatal, severity) => fatal || severity === 2;
 const displayCriteria = function (issue, config) {
 
     // convert the config log level to a number, default to "warning"
-    let severityThreshold = logLevel2Severity[config.minSeverity] || 1;
+    let severityThreshold = severity2Number[config.minSeverity] || 1;
 
     if (issue.severity < severityThreshold) {
         return false;

--- a/lib/issues2eslint.js
+++ b/lib/issues2eslint.js
@@ -18,8 +18,8 @@ const mythx2Severity = {
 };
 
 const logLevel2Severity = {
-    "error": 2,
-    "warning": 1
+    'error': 2,
+    'warning': 1
 };
 
 const isFatal = (fatal, severity) => fatal || severity === 2;
@@ -30,12 +30,12 @@ const displayCriteria = function (issue, config) {
     let severityThreshold = logLevel2Severity[config.minSeverity] || 1;
 
     if (issue.severity < severityThreshold) {
-         return false;
+        return false;
     }
 
     // filter out SWC codes included in the config blacklist
     if (config.swcBlacklist && config.swcBlacklist.includes(issue.ruleId)) {
-         return false;
+        return false;
     }
 
     return true;
@@ -292,8 +292,8 @@ class MythXIssues {
         const sourceName = path.basename(source);
 
         result.messages = issues
-	    .map(issue => this.issue2EsLint(issue, spaceLimited, sourceFormat, sourceName))
-	    .filter(issue => displayCriteria(issue, config));
+            .map(issue => this.issue2EsLint(issue, spaceLimited, sourceFormat, sourceName))
+            .filter(issue => displayCriteria(issue, config));
 
         result.warningCount = result.messages.reduce((acc,  { fatal, severity }) =>
             !isFatal(fatal , severity) ? acc + 1: acc, 0);

--- a/lib/issues2eslint.js
+++ b/lib/issues2eslint.js
@@ -34,7 +34,7 @@ const displayCriteria = function (issue, config) {
     }
 
     // filter out SWC codes included in the config blacklist
-    if (config.swcBlacklist.includes(issue.ruleId)) {
+    if (config.swcBlacklist && config.swcBlacklist.includes(issue.ruleId)) {
 	return false;
     }
 

--- a/lib/issues2eslint.js
+++ b/lib/issues2eslint.js
@@ -30,12 +30,12 @@ const displayCriteria = function (issue, config) {
     let severityThreshold = logLevel2Severity[config.minSeverity] || 1;
 
     if (issue.severity < severityThreshold) {
-	return false;
+         return false;
     }
 
     // filter out SWC codes included in the config blacklist
     if (config.swcBlacklist && config.swcBlacklist.includes(issue.ruleId)) {
-	return false;
+         return false;
     }
 
     return true;

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -836,6 +836,38 @@ describe('helpers.js', function() {
         });
     });
 
+    describe('prepareConfig', () => {
+        it('should return a numeric severityThreshold', () => {
+            const inputSeverity = 'error';
+            const result = helpers.setConfigSeverityLevel(inputSeverity);
+            assert.equal(result, 2);
+        });
+        it('should default to warning if no severity is supplied', () => {
+            const result = helpers.setConfigSeverityLevel();
+            assert.equal(result, 1);
+        });
+        it('should correctly format a comma separated string of swc codes', () => {
+            const commaBlacklist = '103,111';
+            const result = helpers.setConfigSWCBlacklist(commaBlacklist);
+            assert.deepEqual(result, [ 'SWC-103', 'SWC-111' ]);
+        });
+        it('should correctly format a single swc code', () => {
+            const commaBlacklist = '103';
+            const result = helpers.setConfigSWCBlacklist(commaBlacklist);
+            assert.deepEqual(result, [ 'SWC-103' ]);
+        });
+        it('should accept whitespace in the list of swc codes', () => {
+            const commaBlacklist = '103, 111';
+            const result = helpers.setConfigSWCBlacklist(commaBlacklist);
+            assert.deepEqual(result, [ 'SWC-103', 'SWC-111' ]);
+        });
+        it('should accept an arbitrary string as an SWC code without breaking', () => {
+            const commaBlacklist = 'cat';
+            const result = helpers.setConfigSWCBlacklist(commaBlacklist);
+            assert.deepEqual(result, [ 'SWC-cat' ]);
+        });
+    });
+
     describe('getNotFoundContracts', () => {
         it('should return a list containing the not found contracts', () => {
             const allContractNames = ['Contract1', 'Contract2', 'Contract3', 'Contract4'];

--- a/test/test_issue2eslint.js
+++ b/test/test_issue2eslint.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const srcmap = require('../lib/srcmap');
 const mythx = require('../lib/mythx');
 const rewired = rewire('../lib/issues2eslint');
+const issues2eslint = require('../lib/issues2eslint');
 
 describe('issues2Eslint', function() {
     describe('MythXIssues class', () => {
@@ -237,6 +238,13 @@ describe('issues2Eslint', function() {
                 }],
             }]);
         });
+
+	it('should not filter my issue if the project config is left empty', () => {
+	    const issuesObject = newIssueObject();
+	    const issues = [issuesObject];
+	    const filteredIssues = issues.filter(issue => issues2eslint.displayCriteria(issue, {}));
+            assert.deepEqual(issues, filteredIssues);
+	});
 
         it('It normalize and store mythX API output', () => {
             const issuesObject = newIssueObject();

--- a/test/test_issue2eslint.js
+++ b/test/test_issue2eslint.js
@@ -242,7 +242,7 @@ describe('issues2Eslint', function() {
 	      it('should not filter my issue if the project config is left empty', () => {
             const issuesObject = newIssueObject();
             const issues = [issuesObject];
-            const filteredIssues = issues.filter(issue => issues2eslint.displayCriteria(issue, {}));
+            const filteredIssues = issues.filter(issue => issues2eslint.keepIssueInResults(issue, {}));
             assert.deepEqual(issues, filteredIssues);
         });
 

--- a/test/test_issue2eslint.js
+++ b/test/test_issue2eslint.js
@@ -216,7 +216,7 @@ describe('issues2Eslint', function() {
 
             const issuesObject = newIssueObject();
             const remappedMythXOutput = mythx.remapMythXOutput(mythXOutput);
-            const result = remappedMythXOutput.map(output => issuesObject.convertMythXReport2EsIssue(output, true));
+            const result = remappedMythXOutput.map(output => issuesObject.convertMythXReport2EsIssue(output, {}, true));
 
             assert.deepEqual(result, [{
                 errorCount: 1,
@@ -345,7 +345,7 @@ describe('issues2Eslint', function() {
                 }
             }];
             issuesObject.setIssues(mythXOutput);
-            const result = issuesObject.getEslintIssues(true);
+            const result = issuesObject.getEslintIssues({}, true);
             assert.deepEqual(result, [{
                 errorCount: 1,
                 warningCount: 0,

--- a/test/test_issue2eslint.js
+++ b/test/test_issue2eslint.js
@@ -239,7 +239,7 @@ describe('issues2Eslint', function() {
             }]);
         });
 
-	it('should not filter my issue if the project config is left empty', () => {
+	      it('should not filter my issue if the project config is left empty', () => {
             const issuesObject = newIssueObject();
             const issues = [issuesObject];
             const filteredIssues = issues.filter(issue => issues2eslint.displayCriteria(issue, {}));

--- a/test/test_issue2eslint.js
+++ b/test/test_issue2eslint.js
@@ -244,7 +244,7 @@ describe('issues2Eslint', function() {
             const issues = [issuesObject];
             const filteredIssues = issues.filter(issue => issues2eslint.displayCriteria(issue, {}));
             assert.deepEqual(issues, filteredIssues);
-	});
+        });
 
         it('It normalize and store mythX API output', () => {
             const issuesObject = newIssueObject();

--- a/test/test_issue2eslint.js
+++ b/test/test_issue2eslint.js
@@ -240,9 +240,9 @@ describe('issues2Eslint', function() {
         });
 
 	it('should not filter my issue if the project config is left empty', () => {
-	    const issuesObject = newIssueObject();
-	    const issues = [issuesObject];
-	    const filteredIssues = issues.filter(issue => issues2eslint.displayCriteria(issue, {}));
+            const issuesObject = newIssueObject();
+            const issues = [issuesObject];
+            const filteredIssues = issues.filter(issue => issues2eslint.displayCriteria(issue, {}));
             assert.deepEqual(issues, filteredIssues);
 	});
 


### PR DESCRIPTION
This PR is meant to address: https://github.com/ConsenSys/truffle-security/issues/116

The change allows for the creation of a config file named `truffle-security.json` at the truffle project root which consumes this plugin.

Two new configuration options have also been added: `minSeverity` and `swcBlacklist`. These are aimed at providing more granularity over the eslint output.  