### PR TITLE
Bug Fix: ghettoReport does not handle 'No issues found' properly

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -443,14 +443,19 @@ function doReport(config, objects, errors, notAnalyzedContracts) {
 // A stripped-down listing for issues.
 // We will need this until we can beef up information in UUID retrieval
 function ghettoReport(logger, results) {
-    if (results.length === 0) {
+    let issuesCount = 0;
+    results.forEach(ele => {
+        issuesCount += ele.issues.length;
+    });
+    
+    if (issuesCount === 0) {
         logger('No issues found');
         return 0;
     }
     for (const group of results) {
-        logger(group.sourceList.join(', '));
+        logger(group.sourceList.join(', ').underline);
         for (const issue of group.issues) {
-            logger(yaml.safeDump(issue));
+            logger(yaml.safeDump(issue, {'skipInvalid': true}));
         }
     }
     return 1;

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -795,14 +795,16 @@ describe('helpers.js', function() {
             loggerStub = sinon.stub();
         });
 
-        it('should return 0 when results.length is 0', () => {
-            const results = [];
+        it('should return 0 when issues count is 0', () => {
+            const results = [{
+                "issues": [],
+            }];
             const ret = rewiredHelpers.__get__('ghettoReport')(loggerStub, results);
             assert.ok(loggerStub.calledWith('No issues found'));
             assert.equal(ret, 0);
         });
 
-        it('should return 1 when results.length is 1', () => {
+        it('should return 1 when issues count is 1 or more', () => {
             const results = [{
                 'sourceFormat': 'evm-byzantium-bytecode',
                 'sourceList': [
@@ -830,8 +832,8 @@ describe('helpers.js', function() {
 
             const ret = rewiredHelpers.__get__('ghettoReport')(loggerStub, results);
             assert.ok(!loggerStub.calledWith('No issues found'));
-            assert.ok(loggerStub.calledWith('list1, list2'));
-            assert.ok(loggerStub.calledWith(yaml.safeDump(results[0].issues[0])));
+            assert.ok(loggerStub.calledWith('list1, list2'.underline));
+            assert.ok(loggerStub.calledWith(yaml.safeDump(results[0].issues[0], {'skipInvalid': true})));
             assert.equal(ret, 1);
         });
     });


### PR DESCRIPTION
if no issue, `results` which is passed to `ghettoReport` is like below.

```
[
  {
    "issues": [],
    "sourceType": "solidity-file",
    "sourceFormat": "text",
    "sourceList": [
      "/mnt/c/workdir/vscode_project/DividendPayingToken/contracts/DividendPayingToken.sol"
    ],
    "meta": {
      "coveredInstructions": 3169,
      "coveredPaths": 81,
      "selectedCompiler": "0.5.0"
    }
  }
]
```

So even if no issue, it prints contents of `results` as issues.