### PR TITLE
Support compiler of Docker

### DIFF
--- a/compat/truffle-compile/index.js
+++ b/compat/truffle-compile/index.js
@@ -344,7 +344,7 @@ compile.with_dependencies = function(options, callback, compileAll) {
 
   for (const sourcePath of filteredRequired) {
     if (!sourcePath.endsWith('/Migrations.sol')) {
-      Profiler.required_sources(
+      Profiler.imported_sources(
         config.with({
           paths: [sourcePath],
           base_path: options.contracts_directory,


### PR DESCRIPTION
This PR will support compiler of Docker to resolve #145. 
Now it does not use `findImports` func to find imported source code.