### PR TITLE
Fix analysis for new *.sol files

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -567,6 +567,17 @@ const getArmletClient = (ethAddress, password, clientToolName = 'truffle') => {
     return new armlet.Client(options);
 }
 
+const filterDeletedContracts = async contracts => {
+    const filtered = []
+    await Promise.all(contracts.map(async contract => {
+        const isDeleted = await trufstuf.isContractDeleted(contract)
+        if (!isDeleted) {
+            filtered.push(contract)
+        }
+    }))
+    return filtered
+}
+
 /**
  *
  * @param {Object} config - truffle configuration object.
@@ -618,10 +629,12 @@ async function analyze(config) {
     }
 
     const buildObjs = await Promise.all(jsonFiles.map(async file => await trufstuf.parseBuildJson(file)));
-    const objContracts = buildObjs.reduce((resultContracts, obj) => {
+    let objContracts = buildObjs.reduce((resultContracts, obj) => {
         const contracts = mythx.newTruffleObjToOldTruffleByContracts(obj);
         return resultContracts.concat(contracts);
     }, []);
+
+    objContracts = await filterDeletedContracts(objContracts)
     const noDuplicateContracts = removeDuplicateContracts(objContracts);
     const foundContractNames = await getFoundContractNames(noDuplicateContracts, contractNames);
     const notFoundContracts = getNotFoundContracts(contractNames, foundContractNames);

--- a/lib/trufstuf.js
+++ b/lib/trufstuf.js
@@ -43,8 +43,18 @@ const getTruffleBuildJsonFiles = async function(directory) {
 const getSolidityFileFromJson = ({ sourcePath }) => sourcePath;
 
 
+const isContractDeleted = async contract => {
+    try {
+        await util.promisify(fs.stat)(contract.sourcePath)
+    } catch (e) {
+        return true
+    }
+    return false
+}
+
 module.exports = {
     getTruffleBuildJsonFiles,
     getSolidityFileFromJson,
     parseBuildJson,
+    isContractDeleted,
 };


### PR DESCRIPTION
This fixes cases when new solidity files added to `contracts` directory after analysis have been run on existing ones in the project.