### PR TITLE
Display issues with sourceFormat  evm-byzantium-bytecode

### DIFF
--- a/lib/issues2eslint.js
+++ b/lib/issues2eslint.js
@@ -248,7 +248,17 @@ class MythXIssues {
         };
 
         let startLineCol,  endLineCol;
-        const lineBreakPositions = this.lineBreakPositions[sourceName];
+        let lineBreakPositions = this.lineBreakPositions[sourceName];
+
+        /*
+            If lineBreakPositions is undefined use first available.
+            It may happen when API returns bytecode instead of source file name.
+            FIXME: find better way to detect correct source name
+        */
+        if (!lineBreakPositions) {
+            const defaultSourceName = Object.keys(this.lineBreakPositions)[0];
+            lineBreakPositions = this.lineBreakPositions[defaultSourceName];
+        }
 
         if (sourceFormat === 'evm-byzantium-bytecode') {
             // Pick out first byteCode offset value


### PR DESCRIPTION
When analysis return issues with `sourceFormat:  evm-byzantium-bytecode` truffle-security can't detect correct sourcePath and lineBreakPositions. Use first one for cases when lineBreakPoitions not known