### PR TITLE
[Critical] Fix Bug Regarding Link

### DIFF
--- a/compat/truffle-compile/index.js
+++ b/compat/truffle-compile/index.js
@@ -53,12 +53,10 @@ function staleBuildContract (sourcePath, buildPath) {
     return sourceMtime > buildMtime;
 };
 
-
-// Recent versions of truffle seem to add __ to the end of the bytecode
-const cleanBytecode = bytecode => {
-  let cleanedBytecode = bytecode.replace(/_.+$/, '');
-  cleanedBytecode = `0x${cleanedBytecode}`;
-  return cleanedBytecode;
+// Replace link with dummy address
+const replaceLink = bytecode => {
+  const dummyAddress = '0000000000000000000000000000000000000000'
+  return bytecode.replace(/__.{38}/g, dummyAddress)
 }
 
 
@@ -93,8 +91,8 @@ const normalizeJsonOutput = (jsonObject, allSources, options) => {
       for (const [ contractName, contractData ] of Object.entries(solData)) {
           const o = {
               contractName,
-              bytecode: cleanBytecode(contractData.evm.bytecode.object),
-              deployedBytecode: cleanBytecode(contractData.evm.deployedBytecode.object),
+              bytecode: replaceLink(contractData.evm.bytecode.object),
+              deployedBytecode: replaceLink(contractData.evm.deployedBytecode.object),
               sourceMap: contractData.evm.bytecode.sourceMap,
               deployedSourceMap: contractData.evm.deployedBytecode.sourceMap,
           };

--- a/compat/truffle-compile/index.js
+++ b/compat/truffle-compile/index.js
@@ -56,7 +56,7 @@ function staleBuildContract (sourcePath, buildPath) {
 // Replace link with dummy address
 const replaceLink = bytecode => {
   const dummyAddress = '0000000000000000000000000000000000000000'
-  return bytecode.replace(/__.{38}/g, dummyAddress)
+  return '0x' + bytecode.replace(/__.{38}/g, dummyAddress)
 }
 
 


### PR DESCRIPTION
`truffle-security` drops necessary bytecode if link exits in bytecode or deployedBytecode.
That is why, contract using library is not scanned correctly.

### Test solidity file
#### Overflow.sol
```solidity
pragma solidity ^0.5.0;
import "./Lib.sol";
contract Overflow {
  uint public a;
  function add(uint b) public {
    a = Lib.justReturn(a);
    a = a + b;
  }
}
```
#### Lib.sol
```solidity
pragma solidity ^0.5.0;
library Lib {
  function justReturn(uint a) public returns(uint) {
    return a;
  }
}
```

### compiled bytecode with `truffle compile`
```
  "bytecode": "0x608060405234801561001057600080fd5b50610174806100206000396000f3fe60806040526004361061004b5763ffffffff7c01000000000000000000000000000000000000000000000000000000006000350416630dbe671f81146100505780631003e2d214610077575b600080fd5b34801561005c57600080fd5b506100656100a3565b60408051918252519081900360200190f35b34801561008357600080fd5b506100a16004803603602081101561009a57600080fd5b50356100a9565b005b60005481565b73__Lib___________________________________631819856b6000546040518263ffffffff167c01000000000000000000000000000000000000000000000000000000000281526004018082815260200191505060206040518083038186803b15801561011657600080fd5b505af415801561012a573d6000803e3d6000fd5b505050506040513d602081101561014057600080fd5b50510160005556fea165627a7a723058209a9636342319a44c34c662fac01333d3d27bbc751ae0dee33179358c1fae2e740029",
```

### As-Is: truffle-security
#### compiled bytecode (dropped....)
```
"bytecode": "0x608060405234801561001057600080fd5b50610161806100206000396000f3fe608060405234801561001057600080fd5b5060043610610052577c010000000000000000000000000000000000000000000000000000000060003504630dbe671f81146100575780631003e2d214610071575b600080fd5b61005f610090565b60408051918252519081900360200190f35b61008e6004803603602081101561008757600080fd5b5035610096565b005b60005481565b73",
```

#### truffle run verify (could not detect overflow)
```console
Overflow |****************************************************************************************************| 100% || Elapsed: 65.3s ✓ completed

/mnt/c/workdir/vscode_project/MythTest/contracts/Lib.sol
  1:0  warning  A floating pragma is set  SWC-103

✖ 1 problem (0 errors, 1 warning)
```

### To-Be: truffle-security
#### compiled bytecode
```
"bytecode": "608060405234801561001057600080fd5b50610161806100206000396000f3fe608060405234801561001057600080fd5b5060043610610052577c010000000000000000000000000000000000000000000000000000000060003504630dbe671f81146100575780631003e2d214610071575b600080fd5b61005f610090565b60408051918252519081900360200190f35b61008e6004803603602081101561008757600080fd5b5035610096565b005b60005481565b730000000000000000000000000000000000000000631819856b6000546040518263ffffffff167c01000000000000000000000000000000000000000000000000000000000281526004018082815260200191505060206040518083038186803b15801561010357600080fd5b505af4158015610117573d6000803e3d6000fd5b505050506040513d602081101561012d57600080fd5b50510160005556fea165627a7a72305820244373bd79c87958c2be4d843eeddf68c5bedb2e75870b98d6ef85ec681d426d0029",
```

#### truffle run verify
```console
Overflow |****************************************************************************************************| 100% || Elapsed: 66.2s ✓ completed

/mnt/c/workdir/vscode_project/MythTest/contracts/Lib.sol
  1:0  warning  A floating pragma is set  SWC-103

/mnt/c/workdir/vscode_project/MythTest/contracts/Overflow.sol
  7:8  error  The binary addition can overflow  SWC-101

✖ 2 problems (1 error, 1 warning)
```