### PR TITLE
Refactor reading json files and sources keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ module.exports = {
 
 ## Running Security Analyses
 
-Once the plugin is installed the `truffle run verify` becomes available. You can either analyze a specific contract by running `truffle run verify <contract-name>` or the entire project leaving out the contract name.
+Once the plugin is installed the `truffle run verify` becomes available. You can either analyze a specific file by running `truffle run verify <file-name>`, a contract by running `truffle run verify <file-name>:<contract-name>`, or the entire project with simply `truffle run verify`.
 
 **Your project must compile successfully for the security analysis to work.** Note that the `verify` command invokes `truffle compile` automatically if the build files are not up to date.
 
@@ -92,10 +92,10 @@ $ truffle run verify
 ✖ 4 problems (0 errors, 4 warnings)
 ```
 
-Here is an example of analyzing a single contract and using the `table` report style:
+Here is an example of analyzing the same contract passing it in directly and using the `table` report style:
 
 ```
-$ truffle run verify --style table
+$ truffle run verify contracts/Tokensale.sol:Tokensale --style table
 
 /Projects/mythx-playground/exercise2/contracts/Tokensale.sol
 
@@ -120,7 +120,7 @@ Run `truffle run verify --help` to show advanced configuration options.
 ```console
 $ truffle run verify --help
 
-Usage: truffle run verify [options] [*contract-name1* [*contract-name2*] ...]
+Usage: truffle run verify [options] [solidity-file[:contract-name] [solidity-file[:contract-name] ...]]
 
 Runs MythX analyses on given Solidity contracts. If no contracts are
 given, all are analyzed.

--- a/helpers.js
+++ b/helpers.js
@@ -502,21 +502,6 @@ function prepareConfig (config) {
     return config;
 }
 
-const getNotFoundContracts = (allContractNames, foundContracts) => {
-    if (allContractNames) {
-      return allContractNames.filter(function(i) {return foundContracts.indexOf(i) < 0;});
-    }
-    return [];
-}
-
-const getNotAnalyzedContracts = (mythXIssuesObjects, contracts) => {
-    if (!contracts || contracts.length === 0) {
-        return [];
-    }
-    const mythxContracts = mythXIssuesObjects.map(({ contractName }) => contractName);
-    return contracts.filter(c => !mythxContracts.includes(c));
-}
-
 const getArmletClient = (ethAddress, password, clientToolName = 'truffle') => {
     const options = { clientToolName };
     if (password && ethAddress) {
@@ -825,6 +810,4 @@ module.exports = {
     getArmletClient,
     trialEthAddress,
     trialPassword,
-    getNotAnalyzedContracts,
-    getNotFoundContracts,
 };

--- a/helpers.js
+++ b/helpers.js
@@ -74,7 +74,7 @@ function versionJSON2String(jsonResponse) {
  */
 function printHelpMessage() {
     return new Promise(resolve => {
-        const helpMessage = `Usage: truffle run verify [options] [*contract-name1* [*contract-name2*] ...]
+        const helpMessage = `Usage: truffle run verify [options] [solidity-file[:contract-name] [solidity-file[:contract-name] ...]]
 
 Runs MythX analyses on given Solidity contracts. If no contracts are
 given, all are analyzed.

--- a/lib/issues2eslint.js
+++ b/lib/issues2eslint.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const path = require('path');
 const assert = require('assert');
 const SourceMappingDecoder = require(
     'remix-lib/src/sourceMappingDecoder');
@@ -127,11 +126,10 @@ class MythXIssues {
 
     // Is this an issue that should be ignored?
     isIgnorable(sourceMapLocation) {
-        const basename = path.basename(this.sourcePath);
-        if (!( basename in this.asts)) {
+        if (!( this.sourcePath in this.asts)) {
             return false;
         }
-        const ast = this.asts[basename];
+        const ast = this.asts[this.sourcePath];
         const node = srcmap.isVariableDeclaration(sourceMapLocation, ast);
         if (node && srcmap.isDynamicArray(node)) {
             if (this.debug) {
@@ -238,7 +236,7 @@ class MythXIssues {
       *                                     holds the locations that are referred to
       * @returns eslint-issue object
     */
-    issue2EsLint(issue, spaceLimited, sourceFormat, sourceName) {
+    issue2EsLint(issue, spaceLimited, sourceFormat, source) {
         const esIssue = {
             fatal: false,
             ruleId: issue.swcID || 'N/A' ,
@@ -252,7 +250,8 @@ class MythXIssues {
         };
 
         let startLineCol,  endLineCol;
-        let lineBreakPositions = this.lineBreakPositions[sourceName];
+        let lineBreakPositions = this.lineBreakPositions[source];
+
 
         /*
             If lineBreakPositions is undefined use first available.
@@ -303,9 +302,8 @@ class MythXIssues {
             fixableWarningCount: 0,
             filePath: source,
         };
-        const sourceName = path.basename(source);
         result.messages = issues
-            .map(issue => this.issue2EsLint(issue, spaceLimited, sourceFormat, sourceName))
+            .map(issue => this.issue2EsLint(issue, spaceLimited, sourceFormat, source))
             .filter(issue => keepIssueInResults(issue, config));
 
         result.warningCount = result.messages.reduce((acc,  { fatal, severity }) =>

--- a/lib/mythx.js
+++ b/lib/mythx.js
@@ -7,8 +7,8 @@ const newTruffleObjToOldTruffleByContracts = buildObj => {
     let allContracts = [];
 
     const allSources = Object.entries(sources).reduce((accum, [sourcePath, data]) => {
-        const { source, ast, legacyAST } = data;
-        accum[sourcePath] = { ast, legacyAST, source };
+        const { source, ast, legacyAST, id } = data;
+        accum[sourcePath] = { ast, legacyAST, source, id };
         return accum;
     }, {});
 
@@ -44,7 +44,7 @@ const truffle2MythXJSON = function(truffleJSON, toolId = 'truffle-security') {
         compiler: { version },
     } = truffleJSON;
 
-    const sourceList = Object.keys(sources);
+    const sourceList = Object.keys(sources).sort((key1, key2) => sources[key1].id > sources[key2].id);
 
     return {
         contractName,

--- a/lib/mythx.js
+++ b/lib/mythx.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const path = require('path');
-
 // FIXME: Temporary solution, creates an array of objects
 // Each can be passed to MythXIssues constructor
 const newTruffleObjToOldTruffleByContracts = buildObj => {
@@ -10,8 +8,7 @@ const newTruffleObjToOldTruffleByContracts = buildObj => {
 
     const allSources = Object.entries(sources).reduce((accum, [sourcePath, data]) => {
         const { source, ast, legacyAST } = data;
-        const key = path.basename(sourcePath);
-        accum[key] = { ast, legacyAST, source };
+        accum[sourcePath] = { ast, legacyAST, source };
         return accum;
     }, {});
 
@@ -36,7 +33,7 @@ const newTruffleObjToOldTruffleByContracts = buildObj => {
 // Take truffle's build/contracts/xxx.json JSON and make it
 // compatible with the Mythril Platform API
 const truffle2MythXJSON = function(truffleJSON, toolId = 'truffle-security') {
-    let {
+    const {
         contractName,
         bytecode,
         deployedBytecode,
@@ -47,12 +44,7 @@ const truffle2MythXJSON = function(truffleJSON, toolId = 'truffle-security') {
         compiler: { version },
     } = truffleJSON;
 
-    const sourcesKey = path.basename(sourcePath);
-
-    let sourceList = [];
-    for(let key in sources) {
-        sourceList.push(sources[key].ast.absolutePath);
-    }
+    const sourceList = Object.keys(sources);
 
     return {
         contractName,
@@ -60,7 +52,7 @@ const truffle2MythXJSON = function(truffleJSON, toolId = 'truffle-security') {
         deployedBytecode,
         sourceMap,
         deployedSourceMap,
-        mainSource: sourcesKey,
+        mainSource: sourcePath,
         sourceList: sourceList,
         sources,
         toolId,

--- a/lib/wfc.js
+++ b/lib/wfc.js
@@ -21,75 +21,12 @@ const vyperCompile = require('truffle-compile-vyper');
 const externalCompile = require('truffle-external-compile');
 const expect = require('truffle-expect');
 const Resolver = require('truffle-resolver');
-const Artifactor = require('truffle-artifactor');
 const OS = require('os');
 
 const SUPPORTED_COMPILERS = {
     'solc': solcCompile,
     'vyper': vyperCompile,
     'external': externalCompile,
-};
-
-/* A replacement for truffe-artifacts.save, that
-   puts in only MythX-needed fields.
-*/
-const mythXsave = function(object) {
-    var self = this;
-
-    return new Promise(function(accept, reject) {
-
-        if (object.contractName == null) {
-            return reject(new Error('You must specify a contract name.'));
-        }
-
-        delete object.contract_name;
-
-        var outputPath = object.contractName;
-
-        // Create new path off of destination.
-        outputPath = path.join(self.destination, outputPath);
-        outputPath = path.resolve(outputPath);
-
-        // Add json extension.
-        outputPath = outputPath + '.json';
-
-        fs.readFile(outputPath, {encoding: 'utf8'}, function(err, json) {
-            // No need to handle the error. If the file doesn't exist then we'll start afresh
-            // with a new object.
-
-            const finalObject = object;
-
-            if (!err) {
-                try {
-                    JSON.parse(json);
-                } catch (e) {
-                    reject(e);
-                }
-
-                /*
-                // normalize existing and merge into final
-                finalObject = Schema.normalize(existingObjDirty);
-
-                // merge networks
-                var finalNetworks = {};
-                _.merge(finalNetworks, finalObject.networks, object.networks);
-
-                // update existing with new
-                _.assign(finalObject, object);
-                finalObject.networks = finalNetworks;
-                */
-            }
-
-            // update timestamp
-            finalObject.updatedAt = new Date().toISOString();
-
-            // output object
-            fs.outputFile(outputPath, JSON.stringify(finalObject, null, 2), 'utf8', function(err) {
-                if (err) return reject(err);
-                accept();
-            });
-        });
-    });
 };
 
 /* FIXME: if truffle-worflow-compile added a parameter, a directory name
@@ -107,11 +44,6 @@ function prepareConfig(options) {
 
     if (!config.resolver) {
         config.resolver = new Resolver(config);
-    }
-
-    if (!config.artifactor) {
-        config.artifactor = new Artifactor(config.build_mythx_contracts);
-        config.artifactor.save = mythXsave;
     }
 
     return config;

--- a/test/test_issue2eslint.js
+++ b/test/test_issue2eslint.js
@@ -12,7 +12,7 @@ describe('issues2Eslint', function() {
         let truffleJSON;
         const MythXIssues = rewired.__get__('MythXIssues');
         const contractJSON = `${__dirname}/sample-truffle/simple_dao/build/mythx/contracts/simple_dao.json`;
-        const sourceName = 'simple_dao.sol';
+        const sourcePath = '/test/simple_dao/contracts/simple_dao.sol';
 
 	const config = {
 	    debug: false,
@@ -35,7 +35,7 @@ describe('issues2Eslint', function() {
 
         it('should decode a source code location correctly', (done) => {
             const issuesObject = newIssueObject();
-            assert.deepEqual(issuesObject.textSrcEntry2lineColumn('30:2:0', issuesObject.lineBreakPositions[sourceName]),
+            assert.deepEqual(issuesObject.textSrcEntry2lineColumn('30:2:0', issuesObject.lineBreakPositions[sourcePath]),
                 [ { 'line': 2, 'column': 27 }, { 'line': 2, 'column': 29 } ]);
 
             done();
@@ -43,14 +43,14 @@ describe('issues2Eslint', function() {
 
         it('should decode a bytecode offset correctly', (done) => {
             const issuesObject = newIssueObject();
-            assert.deepEqual(issuesObject.byteOffset2lineColumn('100', issuesObject.lineBreakPositions[sourceName]),
+            assert.deepEqual(issuesObject.byteOffset2lineColumn('100', issuesObject.lineBreakPositions[sourcePath]),
                              [ { 'line': 8, 'column': 0 }, { 'line': 25, 'column': 1 } ]);
             done();
         });
 
         it('should decode a bytecode offset to empty result', (done) => {
             const issuesObject = newIssueObject();
-            assert.deepEqual(issuesObject.byteOffset2lineColumn('50', issuesObject.lineBreakPositions[sourceName]),
+            assert.deepEqual(issuesObject.byteOffset2lineColumn('50', issuesObject.lineBreakPositions[sourcePath]),
                              [ { 'line': -1, 'column': 0 }, { } ]);
             done();
         });
@@ -59,7 +59,7 @@ describe('issues2Eslint', function() {
             const mythXOutput = {
                 'sourceFormat': 'evm-byzantium-bytecode',
                 'sourceList': [
-                    `/tmp/contracts/${sourceName}`
+                    sourcePath
                 ],
                 'sourceType': 'raw-bytecode',
                 'issues': [{
@@ -83,7 +83,7 @@ describe('issues2Eslint', function() {
 
             const remappedMythXOutput = mythx.remapMythXOutput(mythXOutput);
             const issuesObject = newIssueObject();
-            const res = issuesObject.issue2EsLint(remappedMythXOutput[0].issues[0], false, 'evm-byzantium-bytecode', sourceName);
+            const res = issuesObject.issue2EsLint(remappedMythXOutput[0].issues[0], false, 'evm-byzantium-bytecode', sourcePath);
 
             assert.deepEqual({
                 ruleId: 'SWC-000',
@@ -104,7 +104,7 @@ describe('issues2Eslint', function() {
                 'sourceType': 'solidity-file',
                 'sourceFormat': 'text',
                 'sourceList': [
-                    `/tmp/contracts/${sourceName}`,
+                    sourcePath
                 ],
                 'issues': [{
                     'description': {
@@ -127,7 +127,7 @@ describe('issues2Eslint', function() {
 
             const remappedMythXOutput = mythx.remapMythXOutput(mythXOutput);
             const issuesObject = newIssueObject();
-            const res = issuesObject.issue2EsLint(remappedMythXOutput[0].issues[0], false, 'text', sourceName);
+            const res = issuesObject.issue2EsLint(remappedMythXOutput[0].issues[0], false, 'text', sourcePath);
 
             assert.deepEqual({
                 ruleId: 'SWC-000',
@@ -194,7 +194,7 @@ describe('issues2Eslint', function() {
                 'sourceType': 'solidity-file',
                 'sourceFormat': 'text',
                 'sourceList': [
-                    `/tmp/contracts/${sourceName}`,
+                    sourcePath,
                 ],
                 'issues': [{
                     'description': {
@@ -224,7 +224,7 @@ describe('issues2Eslint', function() {
                 warningCount: 0,
                 fixableErrorCount: 0,
                 fixableWarningCount: 0,
-                filePath: '/tmp/contracts/simple_dao.sol',
+                filePath: sourcePath,
                 messages: [{
                     column: 4,
                     endCol: 27,
@@ -252,7 +252,7 @@ describe('issues2Eslint', function() {
                 'sourceType': 'solidity-file',
                 'sourceFormat': 'text',
                 'sourceList': [
-                    `/tmp/contracts/${sourceName}`,
+                    sourcePath,
                 ],
                 'issues': [{
                     'description': {
@@ -280,7 +280,7 @@ describe('issues2Eslint', function() {
             assert.deepEqual(issuesObject.issues, [{
                 'sourceType': 'solidity-file',
                 'sourceFormat': 'text',
-                'source': '/tmp/contracts/simple_dao.sol',
+                'source': sourcePath,
                 'issues': [{
                     'description': {
                         'head': 'Head message',
@@ -301,7 +301,7 @@ describe('issues2Eslint', function() {
                 'sourceType': 'solidity-file',
                 'sourceFormat': 'text',
                 'sourceList': [
-                    `/tmp/contracts/${sourceName}`,
+                    sourcePath
                 ],
                 'issues': [{
                     'description': {
@@ -332,7 +332,7 @@ describe('issues2Eslint', function() {
                 'sourceType': 'solidity-file',
                 'sourceFormat': 'text',
                 'sourceList': [
-                    `/tmp/contracts/${sourceName}`,
+                    sourcePath
                 ],
                 'issues': [{
                     'description': {
@@ -359,7 +359,7 @@ describe('issues2Eslint', function() {
                 warningCount: 0,
                 fixableErrorCount: 0,
                 fixableWarningCount: 0,
-                filePath: '/tmp/contracts/simple_dao.sol',
+                filePath: sourcePath,
                 messages: [{
                     ruleId: 'SWC-000',
                     line: 12,

--- a/test/test_mythx.js
+++ b/test/test_mythx.js
@@ -18,12 +18,13 @@ describe('mythx.js', () => {
                 deployedBytecode: truffleJSON.sources[solFilePath].contracts[0].deployedBytecode,
                 sourceMap: truffleJSON.sources[solFilePath].contracts[0].sourceMap,
                 deployedSourceMap: truffleJSON.sources[solFilePath].contracts[0].deployedSourceMap,
-                mainSource: 'simple_dao.sol',
+                mainSource: '/test/simple_dao/contracts/simple_dao.sol',
                 sourceList: [ solFilePath ],
                 sources: {
-                    'simple_dao.sol': {
+                    '/test/simple_dao/contracts/simple_dao.sol': {
                         source: truffleJSON.sources[solFilePath].source,
                         ast: truffleJSON.sources[solFilePath].ast,
+                        id: 0,
                         legacyAST: truffleJSON.sources[solFilePath].legacyAST,
                     },
                 },
@@ -144,6 +145,7 @@ describe('mythx.js', () => {
                 "sources": {
                     "contract.sol": {
                         "ast": {},
+                        "id": 0,
                         "legacyAST": {},
                         "source": "",
                     }
@@ -162,6 +164,7 @@ describe('mythx.js', () => {
                 "sources": {
                     "contract.sol": {
                         "ast": {},
+                        "id": 0,
                         "legacyAST": {},
                         "source": "",
                     }


### PR DESCRIPTION
This changes usage from
```
truffle run verify Contract1
```
to either
```
truffle run verify contracts/file.sol
```
or 
```
truffle run verify contracts/file.sol:Contract1
```

Previously, the chosen buildObj (from a json file) might have had way too much extraneous information, as we were choosing the first one we saw, which could very easily have been a very large contract that imported the one we desire to analyze 3 imports in. This change ensures that the correct buildObj is analyzed; the one directly from the compilation of the file in which the contract was declared in.

The other change this PR makes is fixing the mismatch between the sourceList and the keys of `sources`. They should be the same, but we had previously used the basepath (`contract.sol`) for the keys of `sources`, and the full path (`/home/user/truffleproject/contracts/contract.sol`) for the sourceList. This switches everything over to the full path. This also fixes potential issues with different subdirectories that contain files with the same name.

Things that still need to happen:
 - ~~Update `README.md` and other documentation~~
 - ~~Improve commenting and inline documentation~~
 - ~~Rewrite & fix test cases~~